### PR TITLE
Feature/slack react operator

### DIFF
--- a/airless/hook/notification/slack.py
+++ b/airless/hook/notification/slack.py
@@ -43,3 +43,17 @@ class SlackHook(BaseHook):
             timeout=10
         )
         response.raise_for_status()
+
+    def react(self, channel, reaction, ts):
+        data = {
+            'channel': channel,
+            'name': reaction,
+            'timestamp': ts
+        }
+        response = requests.post(
+            f'https://{self.api_url}/api/reactions.add',
+            headers=self.get_headers(),
+            json=data,
+            timeout=10
+        )
+        response.raise_for_status()

--- a/airless/operator/notification/slack.py
+++ b/airless/operator/notification/slack.py
@@ -25,3 +25,22 @@ class SlackSendOperator(BaseEventOperator):
 
         for channel in channels:
             self.slack_hook.send(channel, message, blocks, thread_ts, reply_broadcast)
+
+
+class SlackReactOperator(BaseEventOperator):
+
+    def __init__(self):
+        super().__init__()
+        self.slack_hook = SlackHook()
+        self.secret_manager_hook = SecretManagerHook()
+
+    def execute(self, data, topic):
+        channel = data['channel']
+        secret_id = data.get('secret_id', 'slack_alert')
+        reaction = data.get('reaction')
+        ts = data.get('ts')
+
+        token = self.secret_manager_hook.get_secret(get_config('GCP_PROJECT'), secret_id, True)['bot_token']
+        self.slack_hook.set_token(token)
+
+        self.slack_hook.react(channel, reaction, ts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless"
-version = "0.0.46"
+version = "0.0.48"
 
 [build-system]
 requires = ["setuptools"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = airless
-version = 0.0.46
+version = 0.0.48
 
 [options]
 packages = find:


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Feature] Create `SlackReactOperator` to react to messages in slack
* [Feature] Create `BaseHttpOperator` to create custom operators with an http trigger instead of pubsub events or gcs files

## Links to issues

> Github issues connected to this PR

