### PR TITLE
Bugfix/change max error timeout to 480 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 **unreleased**
 - [Feature] Add flow to `CONTRIBUTING.md`
+- [Bugfix] Set max error timeout to 480 seconds
 
 **v0.0.49**
 - [Feature] Add automatically semantic version tags with `bump2version`

--- a/airless/operator/error.py
+++ b/airless/operator/error.py
@@ -27,7 +27,7 @@ class ErrorReprocessOperator(BaseEventOperator):
         max_retries = metadata.get('max_retries', 2)
 
         if (input_type == 'event') and (retries < max_retries):
-            time.sleep(min(retry_interval ** retries, 550))  # Cloud function max execution time is 600s, so set it to wait max 550s
+            time.sleep(min(retry_interval ** retries, 480))  # Cloud function max execution time is 540s (9 min), so set it to wait max 480s (8 min)
             original_data.setdefault('metadata', {})['retries'] = retries + 1
             self.pubsub_hook.publish(
                 project=get_config('GCP_PROJECT'),


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Bugfix] Set error max timeout to 480s, because cloud function timeout is 540s

## Links to issues

> Github issues connected to this PR

