### PR TITLE
Feature/add prefix to BatchWriteDetectOperator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Feature] Allow `BatchWriteDetectOperator` to receive a prefix to process only a few files
 
 **v0.0.51**
 - [Feature] Add `options` to method `build_success_message` in class `FileDetectOperator`, to allow pass generic arguments

--- a/airless/hook/google/storage.py
+++ b/airless/hook/google/storage.py
@@ -104,8 +104,12 @@ class GcsHook(BaseHook):
                     for blob in tmp_list:
                         blob.delete()
 
-    def list(self, bucket_name):
-        return self.storage_client.list_blobs(bucket_name, fields='items(name,size,timeCreated,timeDeleted),nextPageToken')
+    def list(self, bucket_name, prefix=None):
+        return self.storage_client.list_blobs(
+            bucket_name,
+            prefix=prefix,
+            fields='items(name,size,timeCreated,timeDeleted),nextPageToken'
+        )
 
 
 class GcsDatalakeHook(GcsHook):

--- a/airless/operator/google/storage.py
+++ b/airless/operator/google/storage.py
@@ -178,12 +178,13 @@ class BatchWriteDetectOperator(BaseEventOperator):
 
     def execute(self, data, topic):
         bucket = data.get('bucket', get_config('GCS_BUCKET_LANDING_ZONE'))
+        prefix = data.get('prefix')
         threshold = data['threshold']
 
         tables = {}
         partially_processed_tables = []
 
-        for b in self.gcs_hook.list(bucket):
+        for b in self.gcs_hook.list(bucket, prefix):
             if b.time_deleted is None:
                 filepaths = b.name.split('/')
                 key = '/'.join(filepaths[:-1])  # dataset/table


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Feature] Add `prefix` param to allow `BatchWriteDetectOperator` to process only certain files

## Links to issues

> Github issues connected to this PR

