### PR TITLE
Bump version: 0.0.51 → 0.0.52

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.51
+current_version = 0.0.52
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.0.52**
 - [Feature] Allow `BatchWriteDetectOperator` to receive a prefix to process only a few files
 
 **v0.0.51**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless"
-version = "0.0.51"
+version = "0.0.52"
 description = "Airless is a package that aims to build a serverless and lightweight orchestration platform, creating workflows of multiple tasks being executed on FaaS platform"
 readme = "README.md"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = airless
-version = 0.0.51
+version = 0.0.52
 
 [options]
 packages = find:


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Feature] Allow `BatchWriteDetectOperator` to receive a prefix to process only a few files

## Links to issues

> Github issues connected to this PR

