### PR TITLE
fix directory when have just one file

### DIFF
--- a/airless/operator/google/storage.py
+++ b/airless/operator/google/storage.py
@@ -316,7 +316,7 @@ class BatchWriteDetectAggregateOperator(BaseEventOperator):
                     self.send_to_process(
                         from_bucket=bucket,
                         to_bucket=get_config('GCS_BUCKET_RAW_ZONE'),
-                        directory=key,
+                        directory=directory,
                         files=v['files'],
                         size=ProcessTopic.SMALL if v['size'] < threshold['size_small'] else ProcessTopic.MEDIUM)
                 elif ((directory in partially_processed_tables) or (v['min_time_created'].strftime('%Y-%m-%d %H:%M') < time_threshold)):


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Bugfix] Change `directory`  from `key` to `directory` because `key` is the used in the previous `for` statement, `directory` is the current `for` statement

## Links to issues

> Github issues connected to this PR

