### PR TITLE
Refactor/change gcs batch size to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Refactor] Change GCS batch size to 100
 
 **v0.0.66**
 - [Refactor] Rewrite logic `BatchWriteDetectAggregateOperator` to be more clear

--- a/airless/hook/google/storage.py
+++ b/airless/hook/google/storage.py
@@ -136,7 +136,7 @@ class GcsHook(BaseHook):
         # the copy operation is faster because it can be sent in batches, which rewrite can't
         # but it can only be used for small files, it can fail to larger files
 
-        batch_size = 1000
+        batch_size = 100
         count = 0
 
         while count < len(blobs):
@@ -162,7 +162,7 @@ class GcsHook(BaseHook):
         self.delete_blobs(blobs)
 
     def delete_blobs(self, blobs):
-        batch_size = 1000
+        batch_size = 100
         count = 0
 
         while count < len(blobs):


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Refactor] Reduce GCS batch size to 100 because the doc says we should keep batch sizes under 100 requests https://cloud.google.com/storage/quotas

## Links to issues

> Github issues connected to this PR

