### PR TITLE
Bump version: 0.0.70 → 0.0.71

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.70
+current_version = 0.0.71
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.0.71**
 - [Feature] Allow file url to gcs operator to save file to a date partitioned directory structure
 
 **v0.0.70**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless"
-version = "0.0.70"
+version = "0.0.71"
 description = "Airless is a package that aims to build a serverless and lightweight orchestration platform, creating workflows of multiple tasks being executed on FaaS platform"
 readme = "README.md"
 dynamic = ["dependencies"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = airless
-version = 0.0.70
+version = 0.0.71
 
 [options]
 packages = find_namespace:


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

- [Feature] Allow file url to gcs operator to save file to a date partitioned directory structure

## Links to issues

> Github issues connected to this PR

