### PR TITLE
change some airless versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Feature] Update `bigquery` package
 
 **v0.0.72**
 - [Feature] Return target filename after uploading data to GCS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-google-cloud-storage==2.6.0
+google-cloud-storage==2.17.0
 google-cloud-pubsub==2.13.11
-google-cloud-bigquery==3.3.6
+google-cloud-bigquery==3.25.0
 google-cloud-secret-manager==2.12.6
 unidecode==1.3.4
 ndjson==0.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,9 +5,9 @@ version = 0.0.72
 [options]
 packages = find_namespace:
 install_requires =
-    google-cloud-storage==2.6.0
+    google-cloud-storage==2.17.0
     google-cloud-pubsub==2.13.11
-    google-cloud-bigquery==3.3.6
+    google-cloud-bigquery==3.25.0
     google-cloud-secret-manager==2.12.6
     unidecode==1.3.4
     ndjson==0.3.1


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Feature] Change bigquery and storage version to not conflict with `scrapegraph-ai`

## Links to issues

> Github issues connected to this PR

