### PR TITLE
Bump version: 0.0.72 → 0.0.73

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.72
+current_version = 0.0.73
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.0.73**
 - [Feature] Update `bigquery` package
 
 **v0.0.72**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless"
-version = "0.0.72"
+version = "0.0.73"
 description = "Airless is a package that aims to build a serverless and lightweight orchestration platform, creating workflows of multiple tasks being executed on FaaS platform"
 readme = "README.md"
 dynamic = ["dependencies"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = airless
-version = 0.0.72
+version = 0.0.73
 
 [options]
 packages = find_namespace:


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Feature] Change bigquery and storage version to not conflict with scrapegraph-ai

## Links to issues

> Github issues connected to this PR

