### PR TITLE
add airless-google-cloud-core to dependencies

### DIFF
--- a/packages/airless-google-cloud-storage/CHANGELOG.md
+++ b/packages/airless-google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Bugfix] Add `airless-google-cloud-core` as a dependency
 
 **v0.0.2**
 - [Feature] Add method `read_as_bytes` to `GcsHook` class

--- a/packages/airless-google-cloud-storage/README.md
+++ b/packages/airless-google-cloud-storage/README.md
@@ -1,5 +1,5 @@
-# airless-email
+# airless-google-cloud-storage
 
-[![PyPI version](https://badge.fury.io/py/airless-email.svg)](https://badge.fury.io/py/airless-email)
+[![PyPI version](https://badge.fury.io/py/airless-google-cloud-storage.svg)](https://badge.fury.io/py/airless-google-cloud-storage)
 
-airless-email were build to work with emails using [Airless](https://github.com/astercapital/airless) module.
+airless-google-cloud-storage was built to interact with google cloud storage using [Airless](https://github.com/astercapital/airless) module.

--- a/packages/airless-google-cloud-storage/requirements.txt
+++ b/packages/airless-google-cloud-storage/requirements.txt
@@ -4,3 +4,4 @@ pyarrow>=11.0.0
 pyarrow<=17.0.0
 
 airless-core>=0.1.0.dev1
+airless-google-cloud-core>=0.0.1.dev1

--- a/packages/airless-google-cloud-storage/setup.cfg
+++ b/packages/airless-google-cloud-storage/setup.cfg
@@ -11,6 +11,7 @@ install_requires =
     pyarrow>=11.0.0
     pyarrow<=17.0.0
     airless-core>=0.1.0.dev1
+    airless-google-cloud-core>=0.0.1.dev1
 
 [options.packages.find]
 include = airless*


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Bugfix] Add `airless-google-cloud-core` as a dependency

## Links to issues

> Github issues connected to this PR

