### PR TITLE
Bugfix/gcs hook read

### DIFF
--- a/packages/airless-google-cloud-storage/.bumpversion.cfg
+++ b/packages/airless-google-cloud-storage/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.7
+current_version = 0.0.8
 commit = True
 tag = True
 tag_name = airless-google-cloud-storage_v{new_version}

--- a/packages/airless-google-cloud-storage/CHANGELOG.md
+++ b/packages/airless-google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Bugfix] GCS hook does not have a `read` function anymore, it was changed to `read_as_string`
 
 **v0.0.7**
 - [Bugfix] Add dynamic dependencies from `requirements.txt` to `pyproject.toml`

--- a/packages/airless-google-cloud-storage/CHANGELOG.md
+++ b/packages/airless-google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.0.8**
 - [Bugfix] GCS hook does not have a `read` function anymore, it was changed to `read_as_string`
 
 **v0.0.7**

--- a/packages/airless-google-cloud-storage/airless/google/cloud/storage/hook/storage.py
+++ b/packages/airless-google-cloud-storage/airless/google/cloud/storage/hook/storage.py
@@ -95,7 +95,7 @@ class GcsHook(BaseHook):
         Returns:
             Any: The content of the JSON file.
         """
-        return json.loads(self.read(bucket, filepath, encoding))
+        return json.loads(self.read_as_string(bucket, filepath, encoding))
 
     def read_ndjson(self, bucket: str, filepath: str, encoding: Optional[str] = None) -> List[Any]:
         """Reads an NDJSON file from GCS.
@@ -108,7 +108,7 @@ class GcsHook(BaseHook):
         Returns:
             List[Any]: The content of the NDJSON file.
         """
-        return ndjson.loads(self.read(bucket, filepath, encoding))
+        return ndjson.loads(self.read_as_string(bucket, filepath, encoding))
 
     def upload_from_memory(
             self,

--- a/packages/airless-google-cloud-storage/pyproject.toml
+++ b/packages/airless-google-cloud-storage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-google-cloud-storage"
-version = "0.0.7"
+version = "0.0.8"
 description = "Airless package to work with google cloud storage"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Bugfix] `read` function from `GcsHook` was renamed to `read_as_string` in version 0.0.2

## Links to issues

> Github issues connected to this PR

