### PR TITLE
Bugfix secret manager `get_secret` method call

### DIFF
--- a/packages/airless-email/CHANGELOG.md
+++ b/packages/airless-email/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [Feature] Create a new command to generate automatically a tag to deploy a new package version
 - [Feature] Automatically generate git tag when bumpversion is triggered
 - [Refactor] Add package name to bumpversion commit message
+- [Bugfix] Add `GCP_PROJECT` param to secret manager get_secret calls
 
 **v0.0.5**
 - [Bugfix] Add dynamic dependencies from `requirements.txt` to `pyproject.toml`

--- a/packages/airless-email/airless/email/hook/email.py
+++ b/packages/airless-email/airless/email/hook/email.py
@@ -15,7 +15,7 @@ class GoogleEmailHook(EmailHook):
         """Initializes the GoogleEmailHook."""
         super().__init__()
         secret_manager_hook = GoogleSecretManagerHook()
-        self.smtp = secret_manager_hook.get_secret(get_config('SECRET_SMTP'), parse_json=True)
+        self.smtp = secret_manager_hook.get_secret(get_config('GCP_PROJECT'), get_config('SECRET_SMTP'), parse_json=True)
 
     def send(self, subject: str, content: str, recipients: List[str], sender: str, attachments: List[dict], mime_type: str) -> None:
         """Sends an email.

--- a/packages/airless-slack/CHANGELOG.md
+++ b/packages/airless-slack/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Bugfix] Add `GCP_PROJECT` param to secret manager get_secret calls
 
 **v0.0.4**
 - [Bugfix] Add dynamic dependencies from `requirements.txt` to `pyproject.toml`

--- a/packages/airless-slack/airless/slack/operator/slack.py
+++ b/packages/airless-slack/airless/slack/operator/slack.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional
 
 from airless.core.operator import BaseEventOperator
 from airless.core.hook import SecretManagerHook
+from airless.core.utils import get_config
 from airless.google.cloud.secret_manager.hook import GoogleSecretManagerHook
 
 from airless.slack.hook import SlackHook
@@ -35,7 +36,7 @@ class SlackSendOperator(BaseEventOperator):
         response_type: Optional[str] = data.get('response_type')
         replace_original: Optional[bool] = data.get('replace_original')
 
-        token: str = self.secret_manager_hook.get_secret(secret_id, True)['bot_token']
+        token: str = self.secret_manager_hook.get_secret(get_config('GCP_PROJECT'), secret_id, True)['bot_token']
         self.slack_hook.set_token(token)
 
         if not channels and not response_url:
@@ -87,7 +88,7 @@ class SlackReactOperator(BaseEventOperator):
         reaction: str = data.get('reaction')
         ts: str = data.get('ts')
 
-        token: str = self.secret_manager_hook.get_secret(secret_id, True)['bot_token']
+        token: str = self.secret_manager_hook.get_secret(get_config('GCP_PROJECT'), secret_id, True)['bot_token']
         self.slack_hook.set_token(token)
 
         response = self.slack_hook.react(channel, reaction, ts)


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Feature] Add `GCP_PROJECT` param to secret manager `get_secret` method in email and slack hooks

## Links to issues

> Github issues connected to this PR

