### PR TITLE
[airless-email] Bump version: 0.0.5 → 0.0.6

### DIFF
--- a/packages/airless-email/.bumpversion.cfg
+++ b/packages/airless-email/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.5
+current_version = 0.0.6
 commit = True
 tag = True
 tag_name = airless-email_v{new_version}

--- a/packages/airless-email/CHANGELOG.md
+++ b/packages/airless-email/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.0.6**
 - [Feature] Create a new command to generate automatically a tag to deploy a new package version
 - [Feature] Automatically generate git tag when bumpversion is triggered
 - [Refactor] Add package name to bumpversion commit message

--- a/packages/airless-email/pyproject.toml
+++ b/packages/airless-email/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-email"
-version = "0.0.5"
+version = "0.0.6"
 description = "Airless package to manage email"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [release] airless-email - Bump version: 0.0.5 → 0.0.6

## Links to issues

> Github issues connected to this PR

