### PR TITLE
Release/update airless core 0.2.1

### DIFF
--- a/packages/airless-captcha/.bumpversion.cfg
+++ b/packages/airless-captcha/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.7
+current_version = 0.1.0
 commit = True
 tag = True
 tag_name = airless-captcha_v{new_version}

--- a/packages/airless-captcha/CHANGELOG.md
+++ b/packages/airless-captcha/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [Feature] Create a new command to generate automatically a tag to deploy a new package version
 - [Feature] Automatically generate git tag when bumpversion is triggered
 - [Refactor] Add package name to bumpversion commit message
+- [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`
 
 **v0.0.7**
 - [Bugfix] Add dynamic dependencies from `requirements.txt` to `pyproject.toml`

--- a/packages/airless-captcha/CHANGELOG.md
+++ b/packages/airless-captcha/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.1.0**
 - [Feature] Create a new command to generate automatically a tag to deploy a new package version
 - [Feature] Automatically generate git tag when bumpversion is triggered
 - [Refactor] Add package name to bumpversion commit message

--- a/packages/airless-captcha/pyproject.toml
+++ b/packages/airless-captcha/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-captcha"
-version = "0.0.7"
+version = "0.1.0"
 description = "Airless Captcha is a package that resolve captcha challenge and based on airless framework"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-captcha/requirements.txt
+++ b/packages/airless-captcha/requirements.txt
@@ -1,2 +1,1 @@
-airless-core>=0.1.1.dev6
-airless-core<0.2.0
+airless-core>=0.2.1,<0.3.0

--- a/packages/airless-email/.bumpversion.cfg
+++ b/packages/airless-email/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.6
+current_version = 0.1.0
 commit = True
 tag = True
 tag_name = airless-email_v{new_version}

--- a/packages/airless-email/CHANGELOG.md
+++ b/packages/airless-email/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`
 
 **v0.0.6**
 - [Feature] Create a new command to generate automatically a tag to deploy a new package version

--- a/packages/airless-email/CHANGELOG.md
+++ b/packages/airless-email/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.1.0**
 - [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`
 
 **v0.0.6**

--- a/packages/airless-email/pyproject.toml
+++ b/packages/airless-email/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-email"
-version = "0.0.6"
+version = "0.1.0"
 description = "Airless package to manage email"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-email/requirements.txt
+++ b/packages/airless-email/requirements.txt
@@ -1,6 +1,3 @@
-airless-core>=0.1.1.dev6
-airless-core<0.2.0
-airless-google-cloud-storage>=0.0.3.dev1
-airless-google-cloud-storage<0.1.0
-airless-google-cloud-secret-manager>=0.0.1.dev1
-airless-google-cloud-secret-manager<0.1.0
+airless-core>=0.2.1,<0.3.0
+airless-google-cloud-storage>=0.1.0,<0.2.0
+airless-google-cloud-secret-manager>=0.1.0,<0.2.0

--- a/packages/airless-google-cloud-bigquery/.bumpversion.cfg
+++ b/packages/airless-google-cloud-bigquery/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.5
+current_version = 0.1.0
 commit = True
 tag = True
 tag_name = airless-google-cloud-bigquery_v{new_version}

--- a/packages/airless-google-cloud-bigquery/CHANGELOG.md
+++ b/packages/airless-google-cloud-bigquery/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [Feature] Create a new command to generate automatically a tag to deploy a new package version
 - [Feature] Automatically generate git tag when bumpversion is triggered
 - [Refactor] Add package name to bumpversion commit message
+- [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`
 
 **v0.0.5**
 - [Bugfix] Add dynamic dependencies from `requirements.txt` to `pyproject.toml`

--- a/packages/airless-google-cloud-bigquery/CHANGELOG.md
+++ b/packages/airless-google-cloud-bigquery/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.1.0**
 - [Feature] Create a new command to generate automatically a tag to deploy a new package version
 - [Feature] Automatically generate git tag when bumpversion is triggered
 - [Refactor] Add package name to bumpversion commit message

--- a/packages/airless-google-cloud-bigquery/pyproject.toml
+++ b/packages/airless-google-cloud-bigquery/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-google-cloud-bigquery"
-version = "0.0.5"
+version = "0.1.0"
 description = "Airless package to works with google cloud bigquery"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-google-cloud-bigquery/requirements.txt
+++ b/packages/airless-google-cloud-bigquery/requirements.txt
@@ -1,8 +1,5 @@
 unidecode==1.3.4
-google-cloud-bigquery>=3.25.0
-google-cloud-bigquery<4.0.0
+google-cloud-bigquery>=3.25.0,<4.0.0
 
-airless-google-cloud-core>=0.0.2.dev1
-airless-google-cloud-core<0.1.0
-airless-google-cloud-storage>=0.0.1.dev2
-airless-google-cloud-storage<0.1.0
+airless-google-cloud-core>=0.1.0,<0.2.0
+airless-google-cloud-storage>=0.1.0,<0.2.0

--- a/packages/airless-google-cloud-secret-manager/.bumpversion.cfg
+++ b/packages/airless-google-cloud-secret-manager/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.4
+current_version = 0.1.0
 commit = True
 tag = True
 tag_name = airless-google-cloud-secret-manager_v{new_version}

--- a/packages/airless-google-cloud-secret-manager/CHANGELOG.md
+++ b/packages/airless-google-cloud-secret-manager/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.1.0**
 - [Feature] Automatically generate git tag when bumpversion is triggered
 - [Refactor] Add package name to bumpversion commit message
 - [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`

--- a/packages/airless-google-cloud-secret-manager/CHANGELOG.md
+++ b/packages/airless-google-cloud-secret-manager/CHANGELOG.md
@@ -2,6 +2,7 @@
 **unreleased**
 - [Feature] Automatically generate git tag when bumpversion is triggered
 - [Refactor] Add package name to bumpversion commit message
+- [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`
 
 **v0.0.4**
 - [Bugfix] Add dynamic dependencies from `requirements.txt` to `pyproject.toml`

--- a/packages/airless-google-cloud-secret-manager/pyproject.toml
+++ b/packages/airless-google-cloud-secret-manager/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-google-cloud-secret-manager"
-version = "0.0.4"
+version = "0.1.0"
 description = "Airless package to manage google secret manager"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-google-cloud-secret-manager/requirements.txt
+++ b/packages/airless-google-cloud-secret-manager/requirements.txt
@@ -1,5 +1,3 @@
-google-cloud-secret-manager>=2.12.6
-google-cloud-secret-manager<3.0.0
+google-cloud-secret-manager>=2.12.6,<3.0.0
 
-airless-core>=0.1.1.dev6
-airless-core<0.2.0
+airless-core>=0.2.1,<0.3.0

--- a/packages/airless-google-cloud-vertexai/.bumpversion.cfg
+++ b/packages/airless-google-cloud-vertexai/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.3
+current_version = 0.1.0
 commit = True
 tag = True
 tag_name = airless-google-cloud-vertexai_v{new_version}

--- a/packages/airless-google-cloud-vertexai/CHANGELOG.md
+++ b/packages/airless-google-cloud-vertexai/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`
 
 **v0.0.3**
 - [Bugfix] Add dynamic dependencies from `requirements.txt` to `pyproject.toml`

--- a/packages/airless-google-cloud-vertexai/CHANGELOG.md
+++ b/packages/airless-google-cloud-vertexai/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.1.0**
 - [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`
 
 **v0.0.3**

--- a/packages/airless-google-cloud-vertexai/pyproject.toml
+++ b/packages/airless-google-cloud-vertexai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-google-cloud-vertexai"
-version = "0.0.3"
+version = "0.1.0"
 description = "Airless package to manage google cloud vertexai"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-google-cloud-vertexai/requirements.txt
+++ b/packages/airless-google-cloud-vertexai/requirements.txt
@@ -1,4 +1,3 @@
 google-cloud-aiplatform>=1.66.0
 google-cloud-aiplatform<2.0.0
-airless-core>=0.1.1.dev6
-airless-core<0.2.0
+airless-core>=0.2.1,<0.3.0

--- a/packages/airless-pdf/.bumpversion.cfg
+++ b/packages/airless-pdf/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.3
+current_version = 0.1.0
 commit = True
 tag = True
 tag_name = airless-pdf_v{new_version}

--- a/packages/airless-pdf/CHANGELOG.md
+++ b/packages/airless-pdf/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`
 
 **v0.0.3**
 - [Bugfix] Add dynamic dependencies from `requirements.txt` to `pyproject.toml`

--- a/packages/airless-pdf/CHANGELOG.md
+++ b/packages/airless-pdf/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.1.0**
 - [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`
 
 **v0.0.3**

--- a/packages/airless-pdf/pyproject.toml
+++ b/packages/airless-pdf/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-pdf"
-version = "0.0.3"
+version = "0.1.0"
 description = "Airless package to manipulate pdf"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-pdf/requirements.txt
+++ b/packages/airless-pdf/requirements.txt
@@ -1,4 +1,2 @@
-airless-core>=0.1.1.dev6
-airless-core<0.2.0
-pymupdf>=1.24.10
-pymupdf<2.0.0
+airless-core>=0.2.1,<0.3.0
+pymupdf>=1.24.10,<2.0.0

--- a/packages/airless-slack/.bumpversion.cfg
+++ b/packages/airless-slack/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.5
+current_version = 0.1.0
 commit = True
 tag = True
 tag_name = airless-slack_v{new_version}

--- a/packages/airless-slack/CHANGELOG.md
+++ b/packages/airless-slack/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`
 
 **v0.0.5**
 - [Bugfix] Add `GCP_PROJECT` param to secret manager get_secret calls

--- a/packages/airless-slack/CHANGELOG.md
+++ b/packages/airless-slack/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.1.0**
 - [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`
 
 **v0.0.5**

--- a/packages/airless-slack/pyproject.toml
+++ b/packages/airless-slack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-slack"
-version = "0.0.5"
+version = "0.1.0"
 description = "Airless package to manage slack"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-slack/requirements.txt
+++ b/packages/airless-slack/requirements.txt
@@ -1,4 +1,2 @@
-airless-core>=0.1.1.dev6
-airless-core<0.2.0
-airless-google-cloud-secret-manager>=0.0.1.dev1
-airless-google-cloud-secret-manager<0.1.0
+airless-core>=0.2.1,<0.3.0
+airless-google-cloud-secret-manager>=0.1.0,<0.2.0


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Refactor] Update all packages to get new `airless-core` version `0.2.1`

## Links to issues

> Github issues connected to this PR

