### PR TITLE
Refactor/avoid error infinite loop

### DIFF
--- a/packages/airless-core/.bumpversion.cfg
+++ b/packages/airless-core/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2
+current_version = 0.2.3
 commit = True
 tag = True
 tag_name = airless-core_v{new_version}

--- a/packages/airless-core/CHANGELOG.md
+++ b/packages/airless-core/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Feature] Do not try to reprocess error from the error function to avoid an infinite loop
 
 **v0.2.2**
 - [Bugfix] Set error operator project as env var

--- a/packages/airless-core/CHANGELOG.md
+++ b/packages/airless-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.2.3**
 - [Feature] Do not try to reprocess error from the error function to avoid an infinite loop
 - [Refactor] If error, email or slack operator project env vars are not set, defaults to the function project, which must be set by the queue hook implementation
 

--- a/packages/airless-core/CHANGELOG.md
+++ b/packages/airless-core/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 **unreleased**
 - [Feature] Do not try to reprocess error from the error function to avoid an infinite loop
+- [Refactor] If error, email or slack operator project env vars are not set, defaults to the function project, which must be set by the queue hook implementation
 
 **v0.2.2**
 - [Bugfix] Set error operator project as env var

--- a/packages/airless-core/airless/core/operator/error.py
+++ b/packages/airless-core/airless/core/operator/error.py
@@ -63,7 +63,7 @@ class ErrorReprocessOperator(BaseEventOperator):
             time.sleep(min(retry_interval ** retries, max_interval))
             original_data.setdefault('metadata', {})['retries'] = retries + 1
             self.queue_hook.publish(
-                project=project or get_config('ERROR_OPERATOR_PROJECT'),
+                project=project or get_config('ERROR_OPERATOR_PROJECT', False),  # if not set, defaults to the function project
                 topic=origin,
                 data=original_data)
 
@@ -96,7 +96,7 @@ class ErrorReprocessOperator(BaseEventOperator):
                 'content': f'Input Type: {data["input_type"]} Origin: {origin}\nMessage ID: {message_id}\n\n {json.dumps(data["data"])}\n\n{data["error"]}'
             }
             self.queue_hook.publish(
-                project=get_config('EMAIL_OPERATOR_PROJECT'),
+                project=get_config('EMAIL_OPERATOR_PROJECT', False),  # if not set, defaults to the function project
                 topic=email_send_topic,
                 data=email_message)
 
@@ -115,6 +115,6 @@ class ErrorReprocessOperator(BaseEventOperator):
                 'message': f'{origin} | {message_id}\n\n{json.dumps(data["data"])}\n\n{data["error"]}'
             }
             self.queue_hook.publish(
-                project=get_config('SLACK_OPERATOR_PROJECT'),
+                project=get_config('SLACK_OPERATOR_PROJECT', False),  # if not set, defaults to the function project
                 topic=slack_send_topic,
                 data=slack_message)

--- a/packages/airless-core/airless/core/operator/error.py
+++ b/packages/airless-core/airless/core/operator/error.py
@@ -59,7 +59,7 @@ class ErrorReprocessOperator(BaseEventOperator):
         error_dataset = metadata.get('dataset')
         error_table = metadata.get('table')
 
-        if (input_type == 'event') and (retries < max_retries):
+        if (input_type == 'event') and (retries < max_retries) and (origin != topic):
             time.sleep(min(retry_interval ** retries, max_interval))
             original_data.setdefault('metadata', {})['retries'] = retries + 1
             self.queue_hook.publish(

--- a/packages/airless-core/pyproject.toml
+++ b/packages/airless-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-core"
-version = "0.2.2"
+version = "0.2.3"
 description = "Airless is a package that aims to build a serverless and lightweight orchestration platform, creating workflows of multiple tasks being executed on FaaS platform"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

- [Feature] Do not try to reprocess error from the error function to avoid an infinite loop
- [Refactor] If error, email or slack operator project env vars are not set, defaults to the function project, which must be set by the queue hook implementation

## Links to issues

> Github issues connected to this PR

