### PR TITLE
Feature/release unused memory from parquet

### DIFF
--- a/packages/airless-core/.bumpversion.cfg
+++ b/packages/airless-core/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.3
+current_version = 0.2.4
 commit = True
 tag = True
 tag_name = airless-core_v{new_version}

--- a/packages/airless-core/CHANGELOG.md
+++ b/packages/airless-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.2.4**
 - [Refactor] Do not convert datetime to string when preparing rows to store in datalake
 - [Refactor] Force a serialization as string for data types json does not know how to serialize, f.i. datetime
 

--- a/packages/airless-core/CHANGELOG.md
+++ b/packages/airless-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+- [Refactor] Do not convert datetime to string when preparing rows to store in datalake
+- [Refactor] Force a serialization as string for data types json does not know how to serialize, f.i. datetime
 
 **v0.2.3**
 - [Feature] Do not try to reprocess error from the error function to avoid an infinite loop

--- a/packages/airless-core/airless/core/hook/datalake.py
+++ b/packages/airless-core/airless/core/hook/datalake.py
@@ -51,7 +51,7 @@ class DatalakeHook(BaseHook):
             '_event_id': metadata['event_id'],
             '_resource': metadata['resource'],
             '_json': json.dumps({'data': row, 'metadata': metadata}),
-            '_created_at': str(now)
+            '_created_at': now
         }
 
     def prepare_rows(self, data: Any, metadata: Dict[str, Any]) -> Tuple[List[Dict[str, Any]], datetime]:

--- a/packages/airless-core/airless/core/hook/file.py
+++ b/packages/airless-core/airless/core/hook/file.py
@@ -58,7 +58,7 @@ class FileHook(BaseHook):
                 f.write(data)
             elif isinstance(data, (dict, list)):
                 dump = ndjson.dump if use_ndjson else json.dump
-                dump(data, f)
+                dump(data, f, default=str)
             else:
                 f.write(str(data))
 

--- a/packages/airless-core/pyproject.toml
+++ b/packages/airless-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-core"
-version = "0.2.3"
+version = "0.2.4"
 description = "Airless is a package that aims to build a serverless and lightweight orchestration platform, creating workflows of multiple tasks being executed on FaaS platform"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-core/tests/core/hook/test_datalake.py
+++ b/packages/airless-core/tests/core/hook/test_datalake.py
@@ -45,7 +45,7 @@ class TestDatalakeHook(unittest.TestCase):
             '_event_id': 1234,
             '_resource': 'local',
             '_json': '{"data": {"foo": "bar"}, "metadata": {"event_id": 1234, "resource": "local"}}',
-            '_created_at': '2025-01-01 09:30:00'
+            '_created_at': now
         }
 
         assert actual_output == expected_output

--- a/packages/airless-core/tests/core/hook/test_file.py
+++ b/packages/airless-core/tests/core/hook/test_file.py
@@ -20,7 +20,7 @@ class TestFileHook(unittest.TestCase):
         self.file_hook.write(local_filepath, data)
 
         mock_file.assert_called_once_with(local_filepath, 'w')
-        mock_json_dump.assert_called_once_with(data, mock_file())
+        mock_json_dump.assert_called_once_with(data, mock_file(), default=str)
 
     @patch('ndjson.dump')
     @patch('builtins.open', new_callable=mock_open)
@@ -30,7 +30,7 @@ class TestFileHook(unittest.TestCase):
         self.file_hook.write(local_filepath, data, use_ndjson=True)
 
         mock_file.assert_called_once_with(local_filepath, 'w')
-        mocK_ndjson_dump.assert_called_once_with(data, mock_file())
+        mocK_ndjson_dump.assert_called_once_with(data, mock_file(), default=str)
 
     def test_extract_filename(self):
         url = 'http://example.com/path/to/file.txt?query=123'

--- a/packages/airless-google-cloud-storage/.bumpversion.cfg
+++ b/packages/airless-google-cloud-storage/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 tag = True
 tag_name = airless-google-cloud-storage_v{new_version}

--- a/packages/airless-google-cloud-storage/CHANGELOG.md
+++ b/packages/airless-google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,8 @@
 
 **unreleased**
+- [Refactor] Write parquet to local file before uploading to GCS because it requires less memory
+- [Feature] Always release unused memory from pyarrow to avoid a memory leak
+- [Refactor] Force parquet schema when creating the parquet table instead of casting it after in order to use less memory
 
 **v0.1.0**
 - [Bugfix] Rollback Google Cloud Storage Operators that were mistakenly deleted

--- a/packages/airless-google-cloud-storage/CHANGELOG.md
+++ b/packages/airless-google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.1.1**
 - [Refactor] Write parquet to local file before uploading to GCS because it requires less memory
 - [Feature] Always release unused memory from pyarrow to avoid a memory leak
 - [Refactor] Force parquet schema when creating the parquet table instead of casting it after in order to use less memory

--- a/packages/airless-google-cloud-storage/airless/google/cloud/storage/hook/datalake.py
+++ b/packages/airless-google-cloud-storage/airless/google/cloud/storage/hook/datalake.py
@@ -1,7 +1,7 @@
 
-from typing import Any, Optional, Union
-
 import pyarrow as pa
+
+from typing import Any, Optional, Union
 
 from airless.core.utils import get_config
 from airless.core.hook import DatalakeHook

--- a/packages/airless-google-cloud-storage/pyproject.toml
+++ b/packages/airless-google-cloud-storage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-google-cloud-storage"
-version = "0.1.0"
+version = "0.1.1"
 description = "Airless package to work with google cloud storage"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-google-cloud-storage/requirements.txt
+++ b/packages/airless-google-cloud-storage/requirements.txt
@@ -1,7 +1,7 @@
 google-cloud-storage>=2.17.0,<3.0.0
 ndjson>=0.3.0,<0.4.0
-pyarrow>=11.0.0,<=17.0.0
+pyarrow>=11.0.0,<=20.0.0
 deprecation>=2.1.0,<2.2.0
 
-airless-core>=0.2.1,<0.3.0
+airless-core>=0.2.4,<0.3.0
 airless-google-cloud-core>=0.1.0,<0.2.0


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

**airless-core**

- [Refactor] Do not convert datetime to string when preparing rows to store in datalake
- [Refactor] Force a serialization as string for data types json does not know how to serialize, f.i. datetime

**airless-google-cloud-storage**

- [Refactor] Write parquet to local file before uploading to GCS because it requires less memory
- [Feature] Always release unused memory from pyarrow to avoid a memory leak
- [Refactor] Force parquet schema when creating the parquet table instead of casting it after in order to use less memory

## Links to issues

> Github issues connected to this PR

