### PR TITLE
Bugfix/event id as int

### DIFF
--- a/packages/airless-core/.bumpversion.cfg
+++ b/packages/airless-core/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.4
+current_version = 0.2.5
 commit = True
 tag = True
 tag_name = airless-core_v{new_version}

--- a/packages/airless-core/CHANGELOG.md
+++ b/packages/airless-core/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Bugfix] Force event id to be an integer
 
 **v0.2.4**
 - [Refactor] Do not convert datetime to string when preparing rows to store in datalake

--- a/packages/airless-core/CHANGELOG.md
+++ b/packages/airless-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.2.5**
 - [Bugfix] Force event id to be an integer
 
 **v0.2.4**

--- a/packages/airless-core/airless/core/hook/datalake.py
+++ b/packages/airless-core/airless/core/hook/datalake.py
@@ -32,7 +32,7 @@ class DatalakeHook(BaseHook):
             Dict[str, Any]: The metadata dictionary.
         """
         return {
-            'event_id': message_id or 1234,
+            'event_id': int(message_id or 1234),
             'resource': origin or 'local'
         }
 

--- a/packages/airless-core/pyproject.toml
+++ b/packages/airless-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-core"
-version = "0.2.4"
+version = "0.2.5"
 description = "Airless is a package that aims to build a serverless and lightweight orchestration platform, creating workflows of multiple tasks being executed on FaaS platform"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-google-cloud-storage/.bumpversion.cfg
+++ b/packages/airless-google-cloud-storage/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2
 commit = True
 tag = True
 tag_name = airless-google-cloud-storage_v{new_version}

--- a/packages/airless-google-cloud-storage/CHANGELOG.md
+++ b/packages/airless-google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.1.2**
 - [Bugfix] Update to `airless-core===0.2.5` because event id was being set as string when it should be an int
 
 **v0.1.1**

--- a/packages/airless-google-cloud-storage/CHANGELOG.md
+++ b/packages/airless-google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Bugfix] Update to `airless-core===0.2.5` because event id was being set as string when it should be an int
 
 **v0.1.1**
 - [Refactor] Write parquet to local file before uploading to GCS because it requires less memory

--- a/packages/airless-google-cloud-storage/pyproject.toml
+++ b/packages/airless-google-cloud-storage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-google-cloud-storage"
-version = "0.1.1"
+version = "0.1.2"
 description = "Airless package to work with google cloud storage"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-google-cloud-storage/requirements.txt
+++ b/packages/airless-google-cloud-storage/requirements.txt
@@ -3,5 +3,5 @@ ndjson>=0.3.0,<0.4.0
 pyarrow>=11.0.0,<=20.0.0
 deprecation>=2.1.0,<2.2.0
 
-airless-core>=0.2.4,<0.3.0
+airless-core>=0.2.5,<0.3.0
 airless-google-cloud-core>=0.1.0,<0.2.0


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

**airless-core**

* [Bugfix] Force `_event_id` to be an int

**airless-google-cloud-storage**

* [Bugfix] Upgrade `airless-core` version to get version where `_event_id` is forced to be an int

## Links to issues

> Github issues connected to this PR

