### PR TITLE
Refactor/airless email secret

### DIFF
--- a/packages/airless-email/.bumpversion.cfg
+++ b/packages/airless-email/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 1.0.0
 commit = True
 tag = True
 tag_name = airless-email_v{new_version}

--- a/packages/airless-email/CHANGELOG.md
+++ b/packages/airless-email/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v1.0.0**
 - [Refactor] Get smtp secret from mounted secret instead of secret manager hook
 
 **v0.1.0**

--- a/packages/airless-email/CHANGELOG.md
+++ b/packages/airless-email/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Refactor] Get smtp secret from mounted secret instead of secret manager hook
 
 **v0.1.0**
 - [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`

--- a/packages/airless-email/pyproject.toml
+++ b/packages/airless-email/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-email"
-version = "0.1.0"
+version = "1.0.0"
 description = "Airless package to manage email"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-email/requirements.txt
+++ b/packages/airless-email/requirements.txt
@@ -1,3 +1,2 @@
 airless-core>=0.2.1,<0.3.0
 airless-google-cloud-storage>=0.1.0,<0.2.0
-airless-google-cloud-secret-manager>=0.1.0,<0.2.0


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Refactor] Get email smtp secret from volume mount instead of secret manager. Using it like this we can remove the dependency with secret manager hook

## Links to issues

> Github issues connected to this PR

