### PR TITLE
Bugfix error handling in GCP airless-slack 

### DIFF
--- a/packages/airless-slack/.bumpversion.cfg
+++ b/packages/airless-slack/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 tag = True
 tag_name = airless-slack_v{new_version}

--- a/packages/airless-slack/CHANGELOG.md
+++ b/packages/airless-slack/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.1.1**
 - [Bugfix] Refactor Google operators to inherit from `GoogleBaseEventOperator`, ensuring proper error handling and consistent use of the `queue_hook` attribute
 
 **v0.1.0**

--- a/packages/airless-slack/CHANGELOG.md
+++ b/packages/airless-slack/CHANGELOG.md
@@ -1,6 +1,6 @@
 
 **unreleased**
-- [Bugfix] Bugfix Google operators to inherit from `GoogleBaseEventOperator` to handle errors and use `queue_hook` attribute
+- [Bugfix] Refactor Google operators to inherit from `GoogleBaseEventOperator`, ensuring proper error handling and consistent use of the `queue_hook` attribute
 
 **v0.1.0**
 - [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`

--- a/packages/airless-slack/CHANGELOG.md
+++ b/packages/airless-slack/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Bugfix] Bugfix Google operators to inherit from `GoogleBaseEventOperator` to handle errors and use `queue_hook` attribute
 
 **v0.1.0**
 - [Refactor] Update requirements.txt to get new `airless-core` version `0.2.1`

--- a/packages/airless-slack/airless/slack/operator/__init__.py
+++ b/packages/airless-slack/airless/slack/operator/__init__.py
@@ -1,6 +1,8 @@
 from .slack import (
     SlackSendOperator,
-    SlackReactOperator,
+    SlackReactOperator
+)
+from .google import (
     GoogleSlackSendOperator,
     GoogleSlackReactOperator
 )

--- a/packages/airless-slack/airless/slack/operator/google.py
+++ b/packages/airless-slack/airless/slack/operator/google.py
@@ -1,0 +1,22 @@
+
+from airless.slack.operator import SlackReactOperator, SlackSendOperator
+from airless.google.cloud.secret_manager.hook import GoogleSecretManagerHook
+from airless.google.cloud.core.operator import GoogleBaseEventOperator
+
+
+class GoogleSlackSendOperator(SlackSendOperator, GoogleBaseEventOperator):
+    """Slack operator using Google Secret Manager to get secrets."""
+
+    def __init__(self) -> None:
+        """Initializes the GoogleSlackSendOperator."""
+        super().__init__()
+        self.secret_manager_hook = GoogleSecretManagerHook()
+
+
+class GoogleSlackReactOperator(SlackReactOperator, GoogleBaseEventOperator):
+    """Slack operator using Google Secret Manager to get secrets."""
+
+    def __init__(self) -> None:
+        """Initializes the GoogleSlackReactOperator."""
+        super().__init__()
+        self.secret_manager_hook = GoogleSecretManagerHook()

--- a/packages/airless-slack/airless/slack/operator/slack.py
+++ b/packages/airless-slack/airless/slack/operator/slack.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional
 from airless.core.operator import BaseEventOperator
 from airless.core.hook import SecretManagerHook
 from airless.core.utils import get_config
-from airless.google.cloud.secret_manager.hook import GoogleSecretManagerHook
 
 from airless.slack.hook import SlackHook
 
@@ -93,21 +92,3 @@ class SlackReactOperator(BaseEventOperator):
 
         response = self.slack_hook.react(channel, reaction, ts)
         self.logger.debug(response)
-
-
-class GoogleSlackSendOperator(SlackSendOperator):
-    """Slack operator using Google Secret Manager to get secrets."""
-
-    def __init__(self) -> None:
-        """Initializes the GoogleSlackSendOperator."""
-        super().__init__()
-        self.secret_manager_hook = GoogleSecretManagerHook()
-
-
-class GoogleSlackReactOperator(SlackReactOperator):
-    """Slack operator using Google Secret Manager to get secrets."""
-
-    def __init__(self) -> None:
-        """Initializes the GoogleSlackReactOperator."""
-        super().__init__()
-        self.secret_manager_hook = GoogleSecretManagerHook()

--- a/packages/airless-slack/pyproject.toml
+++ b/packages/airless-slack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-slack"
-version = "0.1.0"
+version = "0.1.1"
 description = "Airless package to manage slack"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-slack/requirements.txt
+++ b/packages/airless-slack/requirements.txt
@@ -1,2 +1,3 @@
 airless-core>=0.2.1,<0.3.0
+airless-google-cloud-core>=0.1.0,<0.2.0
 airless-google-cloud-secret-manager>=0.1.0,<0.2.0


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

- [Bugfix] Refactor Google operators to inherit from `GoogleBaseEventOperator`, ensuring proper error handling and consistent use of the `queue_hook` attribute

## Links to issues

> Github issues connected to this PR

