### PR TITLE
Feature/pubsub default serializer

### DIFF
--- a/packages/airless-google-cloud-core/.bumpversion.cfg
+++ b/packages/airless-google-cloud-core/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = True
 tag = True
 tag_name = airless-google-cloud-core_v{new_version}

--- a/packages/airless-google-cloud-core/CHANGELOG.md
+++ b/packages/airless-google-cloud-core/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Feature] Default `json.dumps` conversion as `str` when publishing a message to pubsub. For instance, datetime will be converted to str
 
 **v0.1.0**
 - [Refactor] Remove `GoogleErrorReprocessOperator` from `airless-google-cloud-core` because it is being moved to `airless-google-cloud-storage`

--- a/packages/airless-google-cloud-core/CHANGELOG.md
+++ b/packages/airless-google-cloud-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.1.1**
 - [Feature] Default `json.dumps` conversion as `str` when publishing a message to pubsub. For instance, datetime will be converted to str
 
 **v0.1.0**

--- a/packages/airless-google-cloud-core/airless/google/cloud/pubsub/hook/pubsub.py
+++ b/packages/airless-google-cloud-core/airless/google/cloud/pubsub/hook/pubsub.py
@@ -30,7 +30,7 @@ class GooglePubsubHook(QueueHook):
         if get_config('ENV') == 'prod':
             topic_path = self.publisher.topic_path(project or get_config('GCP_PROJECT'), topic)
 
-            message_bytes = json.dumps(data).encode('utf-8')
+            message_bytes = json.dumps(data, default=str).encode('utf-8')
 
             publish_future = self.publisher.publish(topic_path, data=message_bytes)
             publish_future.result(timeout=10)

--- a/packages/airless-google-cloud-core/pyproject.toml
+++ b/packages/airless-google-cloud-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-google-cloud-core"
-version = "0.1.0"
+version = "0.1.1"
 description = "Airless package with the main components to use airless in google cloud"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Feature] Set default serializer to `str` in order to be able to send any class to pubsub, for instance `datetime`

## Links to issues

> Github issues connected to this PR

