### PR TITLE
Feature/serialize as str to datalake

### DIFF
--- a/packages/airless-core/.bumpversion.cfg
+++ b/packages/airless-core/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.5
+current_version = 0.2.6
 commit = True
 tag = True
 tag_name = airless-core_v{new_version}

--- a/packages/airless-core/CHANGELOG.md
+++ b/packages/airless-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.2.6**
 - [Feature] Force a serialization as string when sending data to datalake for data types json does not know how to serialize, f.i. datetime
 
 **v0.2.5**

--- a/packages/airless-core/CHANGELOG.md
+++ b/packages/airless-core/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Feature] Force a serialization as string when sending data to datalake for data types json does not know how to serialize, f.i. datetime
 
 **v0.2.5**
 - [Bugfix] Force event id to be an integer

--- a/packages/airless-core/airless/core/hook/datalake.py
+++ b/packages/airless-core/airless/core/hook/datalake.py
@@ -50,7 +50,7 @@ class DatalakeHook(BaseHook):
         return {
             '_event_id': metadata['event_id'],
             '_resource': metadata['resource'],
-            '_json': json.dumps({'data': row, 'metadata': metadata}),
+            '_json': json.dumps({'data': row, 'metadata': metadata}, default=str),
             '_created_at': now
         }
 

--- a/packages/airless-core/pyproject.toml
+++ b/packages/airless-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-core"
-version = "0.2.5"
+version = "0.2.6"
 description = "Airless is a package that aims to build a serverless and lightweight orchestration platform, creating workflows of multiple tasks being executed on FaaS platform"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Feature] add default `json.dumps` serializer to `str` in order to serialize any type of data to string before sending data to datalake. For instance, `datetime`

## Links to issues

> Github issues connected to this PR

