### PR TITLE
Feature/email array

### DIFF
--- a/.github/workflows/package-validate-reusable-workflow.yml
+++ b/.github/workflows/package-validate-reusable-workflow.yml
@@ -20,10 +20,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.9"
-    - name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2
-      with:
-        credentials_json: '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/package-validate-reusable-workflow.yml
+++ b/.github/workflows/package-validate-reusable-workflow.yml
@@ -20,6 +20,11 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.9"
+    - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/package-validate-reusable-workflow.yml
+++ b/.github/workflows/package-validate-reusable-workflow.yml
@@ -20,11 +20,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.9"
-    - id: auth
-        name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}'
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/packages/airless-email/.bumpversion.cfg
+++ b/packages/airless-email/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.1.0
 commit = True
 tag = True
 tag_name = airless-email_v{new_version}

--- a/packages/airless-email/CHANGELOG.md
+++ b/packages/airless-email/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 **unreleased**
 - [Feature] Create method `recipient_string_to_array` in `GoogleEmailSendOperator` to transform recipients into an email array
+- [Refactor] Remove placeholder `test_fake`
 
 **v1.0.0**
 - [Refactor] Get smtp secret from mounted secret instead of secret manager hook

--- a/packages/airless-email/CHANGELOG.md
+++ b/packages/airless-email/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v1.1.0**
 - [Feature] Create method `recipient_string_to_array` in `GoogleEmailSendOperator` to transform recipients into an email array
 - [Refactor] Remove placeholder `test_fake`
 

--- a/packages/airless-email/CHANGELOG.md
+++ b/packages/airless-email/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Feature] Create method `recipient_string_to_array` in `GoogleEmailSendOperator` to transform recipients into an email array
 
 **v1.0.0**
 - [Refactor] Get smtp secret from mounted secret instead of secret manager hook

--- a/packages/airless-email/airless/email/operator/email.py
+++ b/packages/airless-email/airless/email/operator/email.py
@@ -57,6 +57,7 @@ class GoogleEmailSendOperator(GoogleBaseEventOperator):
         )
 
         return [
-            (r.strip() if '@' in r else r.strip() + '@' + default_domain).lower()
+            (email if '@' in r else f'{email}@{default_domain}').lower()
             for r in recipients_array
+            if (email := r.strip())
         ]

--- a/packages/airless-email/airless/email/operator/email.py
+++ b/packages/airless-email/airless/email/operator/email.py
@@ -50,6 +50,14 @@ class GoogleEmailSendOperator(GoogleBaseEventOperator):
     def recipients_string_to_array(
         self, recipients: Union[List[str], str]
     ) -> List[str]:
+        """Transforms input into an array of emails
+
+        @param recipients: Either a comma separated string with emails and/or usernames or a list of emails and/or usernames
+        @type  recipients: List[str] or str
+
+        @return: List of emails
+        @rtype : List[str]
+        """
         default_domain = get_config('DEFAULT_RECIPIENT_EMAIL_DOMAIN')
 
         recipients_array = (

--- a/packages/airless-email/airless/email/operator/email.py
+++ b/packages/airless-email/airless/email/operator/email.py
@@ -1,6 +1,6 @@
-
 from typing import List
 
+from airless.core.utils import get_config
 from airless.google.cloud.core.operator import GoogleBaseEventOperator
 
 from airless.google.cloud.storage.hook import GcsHook
@@ -25,16 +25,36 @@ class GoogleEmailSendOperator(GoogleBaseEventOperator):
         """
         subject: str = data['subject']
         content: str = data['content']
-        recipients: List[str] = data['recipients']
+        recipients: List[str] | str = data['recipients']
         sender: str = data.get('sender', 'Airless notification')
         attachments: List[dict] = data.get('attachments', [])
         mime_type: str = data.get('mime_type', 'plain')
 
         attachment_contents: List[dict] = []
         for att in attachments:
-            attachment_contents.append({
-                'type': att.get('type', 'text'),
-                'content': self.gcs_hook.read_as_string(att['bucket'], att['filepath'], att['encoding'])
-            })
+            attachment_contents.append(
+                {
+                    'type': att.get('type', 'text'),
+                    'content': self.gcs_hook.read_as_string(
+                        att['bucket'], att['filepath'], att['encoding']
+                    ),
+                }
+            )
 
-        self.email_hook.send(subject, content, recipients, sender, attachment_contents, mime_type)
+        recipients_array = self.recipients_string_to_array(recipients)
+
+        self.email_hook.send(
+            subject, content, recipients_array, sender, attachment_contents, mime_type
+        )
+
+    def recipients_string_to_array(self, recipients) -> List[str]:
+        default_domain = get_config('DEFAULT_RECIPIENT_EMAIL_DOMAIN')
+
+        recipients_array = (
+            recipients if isinstance(recipients, list) else recipients.split(',')
+        )
+
+        return [
+            (r.strip() if '@' in r else r.strip() + '@' + default_domain).lower()
+            for r in recipients_array
+        ]

--- a/packages/airless-email/airless/email/operator/email.py
+++ b/packages/airless-email/airless/email/operator/email.py
@@ -47,7 +47,7 @@ class GoogleEmailSendOperator(GoogleBaseEventOperator):
             subject, content, recipients_array, sender, attachment_contents, mime_type
         )
 
-    def recipients_string_to_array(self, recipients) -> List[str]:
+    def recipients_string_to_array(self, recipients: List[str] | str) -> List[str]:
         default_domain = get_config('DEFAULT_RECIPIENT_EMAIL_DOMAIN')
 
         recipients_array = (

--- a/packages/airless-email/airless/email/operator/email.py
+++ b/packages/airless-email/airless/email/operator/email.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 from airless.core.utils import get_config
 from airless.google.cloud.core.operator import GoogleBaseEventOperator
@@ -25,7 +25,7 @@ class GoogleEmailSendOperator(GoogleBaseEventOperator):
         """
         subject: str = data['subject']
         content: str = data['content']
-        recipients: List[str] | str = data['recipients']
+        recipients: Union[List[str], str] = data['recipients']
         sender: str = data.get('sender', 'Airless notification')
         attachments: List[dict] = data.get('attachments', [])
         mime_type: str = data.get('mime_type', 'plain')
@@ -47,7 +47,9 @@ class GoogleEmailSendOperator(GoogleBaseEventOperator):
             subject, content, recipients_array, sender, attachment_contents, mime_type
         )
 
-    def recipients_string_to_array(self, recipients: List[str] | str) -> List[str]:
+    def recipients_string_to_array(
+        self, recipients: Union[List[str], str]
+    ) -> List[str]:
         default_domain = get_config('DEFAULT_RECIPIENT_EMAIL_DOMAIN')
 
         recipients_array = (

--- a/packages/airless-email/pyproject.toml
+++ b/packages/airless-email/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-email"
-version = "1.0.1.dev1"
+version = "1.0.0"
 description = "Airless package to manage email"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-email/pyproject.toml
+++ b/packages/airless-email/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-email"
-version = "1.0.0"
+version = "1.0.1.dev1"
 description = "Airless package to manage email"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-email/pyproject.toml
+++ b/packages/airless-email/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-email"
-version = "1.0.0"
+version = "1.1.0"
 description = "Airless package to manage email"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-email/tests/email/__init__.py
+++ b/packages/airless-email/tests/email/__init__.py
@@ -1,2 +1,2 @@
 
-nit__.pynit__.py- [Refactor] Remove placeholder `test_fake`
+

--- a/packages/airless-email/tests/email/__init__.py
+++ b/packages/airless-email/tests/email/__init__.py
@@ -1,0 +1,2 @@
+
+nit__.pynit__.py- [Refactor] Remove placeholder `test_fake`

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -5,18 +5,8 @@ from unittest.mock import MagicMock, mock_open, patch
 
 
 class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
-    # @patch.dict(
-    #     os.environ,
-    #     {
-    #         'ENV': 'dev',
-    #         'SECRET_SMTP': 'fake-smtp-file.json',
-    #         'DEFAULT_RECIPIENT_EMAIL_DOMAIN': 'domain.com',
-    #         'QUEUE_TOPIC_ERROR': 'dev-error',
-    #     },
-    # )
     @patch('builtins.open', new_callable=mock_open)
     @patch('airless.google.cloud.storage.hook.GcsHook')
-    # @patch('airless.email.hook.GoogleEmailHook')
     @patch(
         'airless.google.cloud.core.operator.GoogleBaseEventOperator.__init__',
         return_value=None,
@@ -24,7 +14,6 @@ class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
     def setUp(
         self,
         MockGoogleBaseEventOperatorInit,
-        # MockGoogleEmailHook,
         MockGcsHook,
         mock_open_file,
     ):
@@ -33,15 +22,9 @@ class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
         os.environ['DEFAULT_RECIPIENT_EMAIL_DOMAIN'] = 'domain.com'
         os.environ['QUEUE_TOPIC_ERROR'] = 'dev-error'
 
-        # self.magic_email_hook_module = MagicMock()
-        # self.magic_email_hook_module.GoogleEmailHook = MagicMock()
-        # sys.modules['airless.email.hook'] = self.magic_email_hook_module
         mock_file_content = '{"user": "test_user", "password": "test_password", "host": "test_host", "port": 587}'
         mock_file_handle = mock_open_file.return_value
         mock_file_handle.read.return_value = mock_file_content
-
-        # self.mock_gcs_hook_instance = MockGcsHook.return_value
-        # self.mock_email_hook_instance = MockGoogleEmailHook.return_value
 
         from airless.email.operator import GoogleEmailSendOperator
 
@@ -51,7 +34,6 @@ class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
         self.operator.gcs_hook = MagicMock()
 
         # Verify hooks were instantiated
-        # MockGoogleEmailHook.assert_called_once()
         MockGcsHook.assert_called_once()
         MockGoogleBaseEventOperatorInit.assert_called_once()
 

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, mock_open, patch
 
 from airless.email.operator import GoogleEmailSendOperator
 
@@ -14,8 +14,17 @@ class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
         os.environ['ENV'] = 'dev'
         os.environ['QUEUE_TOPIC_ERROR'] = 'dev-error'
         os.environ['DEFAULT_RECIPIENT_EMAIL_DOMAIN'] = 'domain.com'
+        os.environ['SECRET_SMTP'] = 'fake-smtp'
 
-    def test_recipient_string_to_array(self):
+    @patch('builtins.open', new_callable=mock_open)
+    def test_recipient_string_to_array(self, mock_open_file):
+        mock_file_content = '{"user": "test_user", "password": "test_password", "host": "test_host", "port": 587}'
+
+        # Configure the mock_open_file to return our simulated content
+        # when its 'read' method is called.
+        mock_file_handle = mock_open_file.return_value
+        mock_file_handle.read.return_value = mock_file_content
+
         test_data = [
             {'input': 'single', 'expected_output': ['single@domain.com']},
             {

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -21,10 +21,12 @@ class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
         mock_open_file,
         mock_get_config,
     ):
+        mock_get_config.side_effect = lambda key: {
+            'SECRET_SMTP': 'fake-smtp-file.json',
+            'DEFAULT_RECIPIENT_EMAIL_DOMAIN': 'domain.com',
+        }.get(key)
         os.environ['ENV'] = 'dev'
         os.environ['QUEUE_TOPIC_ERROR'] = 'dev-error'
-        os.environ['DEFAULT_RECIPIENT_EMAIL_DOMAIN'] = 'domain.com'
-        os.environ['SECRET_SMTP'] = 'fake-smtp'
 
         mock_file_content = '{"user": "test_user", "password": "test_password", "host": "test_host", "port": 587}'
         mock_file_handle = mock_open_file.return_value

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -1,14 +1,23 @@
 import os
+import sys
 import unittest
 
 from unittest.mock import MagicMock, mock_open, patch
 
 
 class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
-    @patch('airless.core.utils.get_config')
+    # @patch.dict(
+    #     os.environ,
+    #     {
+    #         'ENV': 'dev',
+    #         'SECRET_SMTP': 'fake-smtp-file.json',
+    #         'DEFAULT_RECIPIENT_EMAIL_DOMAIN': 'domain.com',
+    #         'QUEUE_TOPIC_ERROR': 'dev-error',
+    #     },
+    # )
     @patch('builtins.open', new_callable=mock_open)
     @patch('airless.google.cloud.storage.hook.GcsHook')
-    @patch('airless.email.hook.GoogleEmailHook')
+    # @patch('airless.email.hook.GoogleEmailHook')
     @patch(
         'airless.google.cloud.core.operator.GoogleBaseEventOperator.__init__',
         return_value=None,
@@ -16,24 +25,24 @@ class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
     def setUp(
         self,
         MockGoogleBaseEventOperatorInit,
-        MockGoogleEmailHook,
+        # MockGoogleEmailHook,
         MockGcsHook,
         mock_open_file,
-        mock_get_config,
     ):
-        mock_get_config.side_effect = lambda key: {
-            'SECRET_SMTP': 'fake-smtp-file.json',
-            'DEFAULT_RECIPIENT_EMAIL_DOMAIN': 'domain.com',
-        }.get(key)
         os.environ['ENV'] = 'dev'
+        os.environ['SECRET_SMTP'] = 'fake-smtp'
+        os.environ['DEFAULT_RECIPIENT_EMAIL_DOMAIN'] = 'domain.com'
         os.environ['QUEUE_TOPIC_ERROR'] = 'dev-error'
 
+        # self.magic_email_hook_module = MagicMock()
+        # self.magic_email_hook_module.GoogleEmailHook = MagicMock()
+        # sys.modules['airless.email.hook'] = self.magic_email_hook_module
         mock_file_content = '{"user": "test_user", "password": "test_password", "host": "test_host", "port": 587}'
         mock_file_handle = mock_open_file.return_value
         mock_file_handle.read.return_value = mock_file_content
 
-        self.mock_gcs_hook_instance = MockGcsHook.return_value
-        self.mock_email_hook_instance = MockGoogleEmailHook.return_value
+        # self.mock_gcs_hook_instance = MockGcsHook.return_value
+        # self.mock_email_hook_instance = MockGoogleEmailHook.return_value
 
         from airless.email.operator import GoogleEmailSendOperator
 
@@ -43,7 +52,7 @@ class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
         self.operator.gcs_hook = MagicMock()
 
         # Verify hooks were instantiated
-        MockGoogleEmailHook.assert_called_once()
+        # MockGoogleEmailHook.assert_called_once()
         MockGcsHook.assert_called_once()
         MockGoogleBaseEventOperatorInit.assert_called_once()
 

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -3,29 +3,27 @@ import unittest
 
 from unittest.mock import MagicMock, mock_open, patch
 
-from airless.email.operator import GoogleEmailSendOperator
-
-
-os.environ['ENV'] = 'dev'
-os.environ['QUEUE_TOPIC_ERROR'] = 'dev-error'
-os.environ['DEFAULT_RECIPIENT_EMAIL_DOMAIN'] = 'domain.com'
-os.environ['SECRET_SMTP'] = 'fake-smtp'
-
 
 class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
-    def setUp(self):
+    @patch('builtins.open', new_callable=mock_open)
+    def setUp(self, mock_open_file):
+        os.environ['ENV'] = 'dev'
+        os.environ['QUEUE_TOPIC_ERROR'] = 'dev-error'
+        os.environ['DEFAULT_RECIPIENT_EMAIL_DOMAIN'] = 'domain.com'
+        os.environ['SECRET_SMTP'] = 'fake-smtp'
+
+        mock_file_content = '{"user": "test_user", "password": "test_password", "host": "test_host", "port": 587}'
+        mock_file_handle = mock_open_file.return_value
+        mock_file_handle.read.return_value = mock_file_content
+
+        from airless.email.operator import GoogleEmailSendOperator
+
         self.operator = GoogleEmailSendOperator()
         self.operator.queue_hook = MagicMock()
         self.operator.email_hook = MagicMock()
         self.operator.gcs_hook = MagicMock()
 
-    @patch('builtins.open', new_callable=mock_open)
-    def test_recipient_string_to_array(self, mock_open_file):
-        mock_file_content = '{"user": "test_user", "password": "test_password", "host": "test_host", "port": 587}'
-
-        mock_file_handle = mock_open_file.return_value
-        mock_file_handle.read.return_value = mock_file_content
-
+    def test_recipient_string_to_array(self):
         test_data = [
             {'input': 'single', 'expected_output': ['single@domain.com']},
             {

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -6,16 +6,16 @@ from unittest.mock import MagicMock, mock_open, patch
 from airless.email.operator import GoogleEmailSendOperator
 
 
+@patch.dict(
+    os.environ,
+    {
+        'ENV': 'dev',
+        'QUEUE_TOPIC_ERROR': 'dev-error',
+        'DEFAULT_RECIPIENT_EMAIL_DOMAIN': 'domain.com',
+        'SECRET_SMTP': 'fake-smtp',
+    },
+)
 class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
-    @patch.dict(
-        os.environ,
-        {
-            'ENV': 'dev',
-            'QUEUE_TOPIC_ERROR': 'dev-error',
-            'DEFAULT_RECIPIENT_EMAIL_DOMAIN': 'domain.com',
-            'SECRET_SMTP': 'fake-smtp',
-        },
-    )
     def setUp(self):
         self.operator = GoogleEmailSendOperator()
         self.operator.queue_hook = MagicMock()

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -6,15 +6,12 @@ from unittest.mock import MagicMock, mock_open, patch
 from airless.email.operator import GoogleEmailSendOperator
 
 
-@patch.dict(
-    os.environ,
-    {
-        'ENV': 'dev',
-        'QUEUE_TOPIC_ERROR': 'dev-error',
-        'DEFAULT_RECIPIENT_EMAIL_DOMAIN': 'domain.com',
-        'SECRET_SMTP': 'fake-smtp',
-    },
-)
+os.environ['ENV'] = 'dev'
+os.environ['QUEUE_TOPIC_ERROR'] = 'dev-error'
+os.environ['DEFAULT_RECIPIENT_EMAIL_DOMAIN'] = 'domain.com'
+os.environ['SECRET_SMTP'] = 'fake-smtp'
+
+
 class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
     def setUp(self):
         self.operator = GoogleEmailSendOperator()

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -8,13 +8,13 @@ from airless.email.operator import GoogleEmailSendOperator
 
 class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
     def setUp(self):
-        self.operator = GoogleEmailSendOperator()
-        self.operator.queue_hook = MagicMock()
-
         os.environ['ENV'] = 'dev'
         os.environ['QUEUE_TOPIC_ERROR'] = 'dev-error'
         os.environ['DEFAULT_RECIPIENT_EMAIL_DOMAIN'] = 'domain.com'
         os.environ['SECRET_SMTP'] = 'fake-smtp'
+
+        self.operator = GoogleEmailSendOperator()
+        self.operator.queue_hook = MagicMock()
 
     @patch('builtins.open', new_callable=mock_open)
     def test_recipient_string_to_array(self, mock_open_file):

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -7,21 +7,25 @@ from airless.email.operator import GoogleEmailSendOperator
 
 
 class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
+    @patch.dict(
+        os.environ,
+        {
+            'ENV': 'dev',
+            'QUEUE_TOPIC_ERROR': 'dev-error',
+            'DEFAULT_RECIPIENT_EMAIL_DOMAIN': 'domain.com',
+            'SECRET_SMTP': 'fake-smtp',
+        },
+    )
     def setUp(self):
-        os.environ['ENV'] = 'dev'
-        os.environ['QUEUE_TOPIC_ERROR'] = 'dev-error'
-        os.environ['DEFAULT_RECIPIENT_EMAIL_DOMAIN'] = 'domain.com'
-        os.environ['SECRET_SMTP'] = 'fake-smtp'
-
         self.operator = GoogleEmailSendOperator()
         self.operator.queue_hook = MagicMock()
+        self.operator.email_hook = MagicMock()
+        self.operator.gcs_hook = MagicMock()
 
     @patch('builtins.open', new_callable=mock_open)
     def test_recipient_string_to_array(self, mock_open_file):
         mock_file_content = '{"user": "test_user", "password": "test_password", "host": "test_host", "port": 587}'
 
-        # Configure the mock_open_file to return our simulated content
-        # when its 'read' method is called.
         mock_file_handle = mock_open_file.return_value
         mock_file_handle.read.return_value = mock_file_content
 

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import unittest
 
 from unittest.mock import MagicMock, mock_open, patch

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -35,6 +35,17 @@ class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
                 'input': ['complete', 'foo@bar.com'],
                 'expected_output': ['complete@domain.com', 'foo@bar.com'],
             },
+            {
+                'input': 'foo,,bar',
+                'expected_output': ['foo@domain.com', 'bar@domain.com'],
+            },
+            {'input': '  user@domain.com  ', 'expected_output': ['user@domain.com']},
+            {'input': '', 'expected_output': []},
+            {'input': [], 'expected_output': []},
+            {
+                'input': ['foo', '', 'bar'],
+                'expected_output': ['foo@domain.com', 'bar@domain.com'],
+            },
         ]
 
         for td in test_data:

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -1,0 +1,44 @@
+import os
+import unittest
+
+from unittest.mock import MagicMock
+
+from airless.email.operator import GoogleEmailSendOperator
+
+
+class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
+    def setUp(self):
+        self.operator = GoogleEmailSendOperator()
+        self.operator.queue_hook = MagicMock()
+
+        os.environ['ENV'] = 'dev'
+        os.environ['QUEUE_TOPIC_ERROR'] = 'dev-error'
+        os.environ['DEFAULT_RECIPIENT_EMAIL_DOMAIN'] = 'domain.com'
+
+    def test_recipient_string_to_array(self):
+        test_data = [
+            {'input': 'single', 'expected_output': ['single@domain.com']},
+            {
+                'input': 'multiple1,multiple2',
+                'expected_output': ['multiple1@domain.com', 'multiple2@domain.com'],
+            },
+            {
+                'input': 'complete,foo@bar.com',
+                'expected_output': ['complete@domain.com', 'foo@bar.com'],
+            },
+            {'input': ['single'], 'expected_output': ['single@domain.com']},
+            {
+                'input': ['multiple1', 'multiple2'],
+                'expected_output': ['multiple1@domain.com', 'multiple2@domain.com'],
+            },
+            {
+                'input': ['complete', 'foo@bar.com'],
+                'expected_output': ['complete@domain.com', 'foo@bar.com'],
+            },
+        ]
+
+        for td in test_data:
+            self.assertEqual(
+                self.operator.recipients_string_to_array(td['input']),
+                td['expected_output'],
+            )

--- a/packages/airless-email/tests/email/operator/test_email.py
+++ b/packages/airless-email/tests/email/operator/test_email.py
@@ -11,6 +11,7 @@ class TestGoogleEmailSendOperatorOperator(unittest.TestCase):
         os.environ['QUEUE_TOPIC_ERROR'] = 'dev-error'
         os.environ['DEFAULT_RECIPIENT_EMAIL_DOMAIN'] = 'domain.com'
         os.environ['SECRET_SMTP'] = 'fake-smtp'
+        os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = '{}'
 
         mock_file_content = '{"user": "test_user", "password": "test_password", "host": "test_host", "port": 587}'
         mock_file_handle = mock_open_file.return_value

--- a/packages/airless-email/tests/test_fake.py
+++ b/packages/airless-email/tests/test_fake.py
@@ -1,3 +1,0 @@
-
-def test_fake():
-    assert 1 == 1


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

- [Feature] Create method `recipient_string_to_array` in `GoogleEmailSendOperator` to transform recipients into an email array. This is a logic that is always repeated by the operator before sending it to this operator, so we should implement it here and centralized its implementation

## Links to issues

> Github issues connected to this PR

