### PR TITLE
Fix: Ensure message_id is int for Parquet schema

### DIFF
--- a/packages/airless-core/airless/core/operator/base.py
+++ b/packages/airless-core/airless/core/operator/base.py
@@ -5,6 +5,8 @@ import traceback
 
 from base64 import b64decode
 
+from typing import Optional
+
 from airless.core import BaseClass
 from airless.core.utils import get_config
 from airless.core.hook import QueueHook
@@ -34,16 +36,23 @@ class BaseOperator(BaseClass):
         self.message_id = None
         self.has_error = False
 
-    def extract_message_id(self, cloud_event) -> str:
+    def extract_message_id(self, cloud_event) -> Optional[int]:
         """Extracts the message ID from the cloud event.
 
         Args:
             cloud_event (CloudEvent): The cloud event from which to extract the message ID.
 
         Returns:
-            str: The extracted message ID.
+            Optional[int]: The extracted message ID as an integer, or None if extraction fails.
         """
-        return cloud_event['id']
+        message_id_str = cloud_event.get('id')
+        if message_id_str:
+            try:
+                return int(message_id_str)
+            except ValueError:
+                self.logger.warning(f"Could not parse message_id '{message_id_str}' as an integer.")
+                return None
+        return None
 
     def report_error(self, message: str, data: dict=None):
         """Reports an error by logging it and publishing to a queue.

--- a/packages/airless-core/tests/core/operator/test_base.py
+++ b/packages/airless-core/tests/core/operator/test_base.py
@@ -20,7 +20,7 @@ class TestBaseOperator(unittest.TestCase):
     def test_extract_message_id(self):
         cloud_event = {'id': '12345'}
         message_id = self.operator.extract_message_id(cloud_event)
-        self.assertEqual(message_id, '12345')
+        self.assertEqual(message_id, 12345)
 
     def test_report_error(self):
         self.operator.build_error_message = MagicMock()

--- a/packages/airless-core/tests/core/operator/test_error.py
+++ b/packages/airless-core/tests/core/operator/test_error.py
@@ -82,20 +82,20 @@ class TestErrorReprocessOperator(unittest.TestCase):
             data=data,
             dataset='error_dataset',
             table='error_table',
-            message_id='12345',
+            message_id=12345,
             origin='source_topic',
             time_partition=True
         )
 
         notify_slack.assert_called_once_with(
             origin='source_topic',
-            message_id='12345',
+            message_id=12345,
             data=data
         )
 
         notify_email.assert_called_once_with(
             origin='source_topic',
-            message_id='12345',
+            message_id=12345,
             data=data
         )
 
@@ -129,20 +129,20 @@ class TestErrorReprocessOperator(unittest.TestCase):
             data=data,
             dataset='env_error_dataset',
             table='env_error_table',
-            message_id='12345',
+            message_id=12345,
             origin='source_topic',
             time_partition=True
         )
 
         notify_slack.assert_called_once_with(
             origin='source_topic',
-            message_id='12345',
+            message_id=12345,
             data=data
         )
 
         notify_email.assert_called_once_with(
             origin='source_topic',
-            message_id='12345',
+            message_id=12345,
             data=data
         )
 
@@ -197,20 +197,20 @@ class TestErrorReprocessOperator(unittest.TestCase):
             data=data,
             dataset='error_dataset',
             table='error_table',
-            message_id='12345',
+            message_id=12345,
             origin='source_topic',
             time_partition=True
         )
 
         notify_slack.assert_called_once_with(
             origin='source_topic',
-            message_id='12345',
+            message_id=12345,
             data=data
         )
 
         notify_email.assert_called_once_with(
             origin='source_topic',
-            message_id='12345',
+            message_id=12345,
             data=data
         )
 
@@ -241,20 +241,20 @@ class TestErrorReprocessOperator(unittest.TestCase):
             data=data,
             dataset='error_dataset',
             table='error_table',
-            message_id='12345',
+            message_id=12345,
             origin='error-topic',
             time_partition=True
         )
 
         notify_slack.assert_called_once_with(
             origin='error-topic',
-            message_id='12345',
+            message_id=12345,
             data=data
         )
 
         notify_email.assert_called_once_with(
             origin='error-topic',
-            message_id='12345',
+            message_id=12345,
             data=data
         )
 


### PR DESCRIPTION
Addresses issue #121 where `message_id` was sometimes a string, causing type errors with the Parquet schema which expects an int (int64).

Changes:
- Modified `BaseOperator.extract_message_id` to parse the ID to `Optional[int]`.
- Updated `ErrorReprocessOperator` to parse `event_id` from input data to `Optional[int]` before passing to datalake and notification methods.
- Ensured type hints and test assertions align with `Optional[int]` for `message_id` / `event_id` in relevant areas of `airless-core`.
- Verified that `send_to_landing_zone` in `airless-google-cloud-storage` correctly expects `Optional[int]`.
- All relevant tests in `airless-core` now pass.


## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Feature] Implemented feature xyz because abc

## Links to issues

> Github issues connected to this PR

