### PR TITLE
Feature/send slack message to user emails

### DIFF
--- a/packages/airless-slack/.bumpversion.cfg
+++ b/packages/airless-slack/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = True
 tag = True
 tag_name = airless-slack_v{new_version}

--- a/packages/airless-slack/.bumpversion.cfg
+++ b/packages/airless-slack/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.4.0
 commit = True
 tag = True
 tag_name = airless-slack_v{new_version}

--- a/packages/airless-slack/CHANGELOG.md
+++ b/packages/airless-slack/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.4.0**
 - [Feature] Support sending messages to users (DM) via user ID (in `channels`) or `user_emails`
 
 **v0.3.0**

--- a/packages/airless-slack/CHANGELOG.md
+++ b/packages/airless-slack/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Bugfix] Guard against `None` values for `channels`/`user_emails`, dedupe `user_emails` before lookup, and use safe dict access on the Slack `users.lookupByEmail` response
 
 **v0.4.0**
 - [Feature] Support sending messages to users (DM) via user ID (in `channels`) or `user_emails`

--- a/packages/airless-slack/CHANGELOG.md
+++ b/packages/airless-slack/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Feature] Support sending messages to users (DM) via user ID (in `channels`) or `user_emails`
 
 **v0.3.0**
 - [Refactor] Remove airless dependency limitation

--- a/packages/airless-slack/CHANGELOG.md
+++ b/packages/airless-slack/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.4.1**
 - [Bugfix] Guard against `None` values for `channels`/`user_emails`, dedupe `user_emails` before lookup, and use safe dict access on the Slack `users.lookupByEmail` response
 
 **v0.4.0**

--- a/packages/airless-slack/airless/slack/hook/slack.py
+++ b/packages/airless-slack/airless/slack/hook/slack.py
@@ -106,10 +106,14 @@ class SlackHook(BaseHook):
         response.raise_for_status()
         response_json = response.json()
 
-        if not response_json['ok']:
-            raise Exception(f"Failed to lookup Slack user by email '{email}': {response_json['error']}")
+        if not response_json.get('ok'):
+            raise Exception(f"Failed to lookup Slack user by email '{email}': {response_json.get('error', 'unknown error')}")
 
-        return response_json['user']['id']
+        user_id = (response_json.get('user') or {}).get('id')
+        if not user_id:
+            raise Exception(f"Failed to lookup Slack user by email '{email}': missing user id in response")
+
+        return user_id
 
     def react(self, channel: str, reaction: str, ts: str) -> Dict[str, Any]:
         """Adds a reaction to a Slack message.

--- a/packages/airless-slack/airless/slack/hook/slack.py
+++ b/packages/airless-slack/airless/slack/hook/slack.py
@@ -88,6 +88,29 @@ class SlackHook(BaseHook):
             return {'status': response.text}
         return response.json()
 
+    def get_user_id_by_email(self, email: str) -> str:
+        """Resolves a Slack user ID from their email address.
+
+        Args:
+            email (str): The user's email address.
+
+        Returns:
+            str: The Slack user ID.
+        """
+        response = requests.get(
+            f'https://{self.api_url}/api/users.lookupByEmail',
+            headers=self.get_headers(),
+            params={'email': email},
+            timeout=10
+        )
+        response.raise_for_status()
+        response_json = response.json()
+
+        if not response_json['ok']:
+            raise Exception(f"Failed to lookup Slack user by email '{email}': {response_json['error']}")
+
+        return response_json['user']['id']
+
     def react(self, channel: str, reaction: str, ts: str) -> Dict[str, Any]:
         """Adds a reaction to a Slack message.
 

--- a/packages/airless-slack/airless/slack/operator/slack.py
+++ b/packages/airless-slack/airless/slack/operator/slack.py
@@ -1,4 +1,3 @@
-
 from typing import Any, Dict, List, Optional
 
 from airless.core.operator import BaseEventOperator
@@ -27,8 +26,8 @@ class SlackSendOperator(BaseEventOperator):
                 Slack user ID before sending a DM.
             topic (str): The Pub/Sub topic.
         """
-        channels: List[str] = data.get('channels', [])
-        user_emails: List[str] = data.get('user_emails', [])
+        channels: List[str] = data.get('channels') or []
+        user_emails: List[str] = data.get('user_emails') or []
         secret_id: str = data.get('secret_id', 'slack_alert')
         message: str = data.get('message')
         blocks: Optional[List[Dict[str, Any]]] = data.get('blocks')
@@ -39,18 +38,22 @@ class SlackSendOperator(BaseEventOperator):
         response_type: Optional[str] = data.get('response_type')
         replace_original: Optional[bool] = data.get('replace_original')
 
-        token: str = self.secret_manager_hook.get_secret(get_config('GCP_PROJECT'), secret_id, True)['bot_token']
+        token: str = self.secret_manager_hook.get_secret(
+            get_config('GCP_PROJECT'), secret_id, True
+        )['bot_token']
         self.slack_hook.set_token(token)
 
         if not channels and not user_emails and not response_url:
             raise Exception('Either channels, user_emails or response_url must be set')
 
         recipients = set(channels)
-        for email in user_emails:
+        for email in set(user_emails):
             try:
                 recipients.add(self.slack_hook.get_user_id_by_email(email))
             except Exception as e:
-                self.logger.error(f"Failed to resolve Slack user by email '{email}': {e}")
+                self.logger.error(
+                    f"Failed to resolve Slack user by email '{email}': {e}"
+                )
 
         for channel in recipients:
             response = self.slack_hook.send(
@@ -61,7 +64,8 @@ class SlackSendOperator(BaseEventOperator):
                 reply_broadcast=reply_broadcast,
                 attachments=attachments,
                 response_type=response_type,
-                replace_original=replace_original)
+                replace_original=replace_original,
+            )
             self.logger.debug(response)
 
         if response_url:
@@ -73,7 +77,8 @@ class SlackSendOperator(BaseEventOperator):
                 attachments=attachments,
                 response_url=response_url,
                 response_type=response_type,
-                replace_original=replace_original)
+                replace_original=replace_original,
+            )
             self.logger.debug(response)
 
 
@@ -98,7 +103,9 @@ class SlackReactOperator(BaseEventOperator):
         reaction: str = data.get('reaction')
         ts: str = data.get('ts')
 
-        token: str = self.secret_manager_hook.get_secret(get_config('GCP_PROJECT'), secret_id, True)['bot_token']
+        token: str = self.secret_manager_hook.get_secret(
+            get_config('GCP_PROJECT'), secret_id, True
+        )['bot_token']
         self.slack_hook.set_token(token)
 
         response = self.slack_hook.react(channel, reaction, ts)

--- a/packages/airless-slack/airless/slack/operator/slack.py
+++ b/packages/airless-slack/airless/slack/operator/slack.py
@@ -22,9 +22,13 @@ class SlackSendOperator(BaseEventOperator):
 
         Args:
             data (Dict[str, Any]): The data containing message information.
+                `channels` accepts channel IDs and/or user IDs (Slack opens a DM
+                automatically for user IDs). `user_emails` resolves each email to a
+                Slack user ID before sending a DM.
             topic (str): The Pub/Sub topic.
         """
         channels: List[str] = data.get('channels', [])
+        user_emails: List[str] = data.get('user_emails', [])
         secret_id: str = data.get('secret_id', 'slack_alert')
         message: str = data.get('message')
         blocks: Optional[List[Dict[str, Any]]] = data.get('blocks')
@@ -38,10 +42,17 @@ class SlackSendOperator(BaseEventOperator):
         token: str = self.secret_manager_hook.get_secret(get_config('GCP_PROJECT'), secret_id, True)['bot_token']
         self.slack_hook.set_token(token)
 
-        if not channels and not response_url:
-            raise Exception('Either channels or response_url must be set')
+        if not channels and not user_emails and not response_url:
+            raise Exception('Either channels, user_emails or response_url must be set')
 
-        for channel in channels:
+        recipients = set(channels)
+        for email in user_emails:
+            try:
+                recipients.add(self.slack_hook.get_user_id_by_email(email))
+            except Exception as e:
+                self.logger.error(f"Failed to resolve Slack user by email '{email}': {e}")
+
+        for channel in recipients:
             response = self.slack_hook.send(
                 channel=channel,
                 message=message,

--- a/packages/airless-slack/pyproject.toml
+++ b/packages/airless-slack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-slack"
-version = "0.4.0"
+version = "0.4.1"
 description = "Airless package to manage slack"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-slack/pyproject.toml
+++ b/packages/airless-slack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-slack"
-version = "0.3.0"
+version = "0.4.0"
 description = "Airless package to manage slack"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Feature] Allow the slack operator to send a message to a user via DM using the user email instead of the user ID

## Links to issues

> Github issues connected to this PR

