### PR TITLE
Bugfix/problem renaming file cloud run functions

### DIFF
--- a/packages/airless-core/.bumpversion.cfg
+++ b/packages/airless-core/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.5.1
 commit = True
 tag = True
 tag_name = airless-core_v{new_version}

--- a/packages/airless-core/CHANGELOG.md
+++ b/packages/airless-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.5.1**
 - [Bugfix] Remove `os.rename` calls because cloud run functions is throwing errors `[Errno 1] Operation not permitted` when calling it. Replace it by `os.link` + `os.remove`
 
 **v0.5.0**

--- a/packages/airless-core/CHANGELOG.md
+++ b/packages/airless-core/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Bugfix] Remove `os.rename` calls because cloud run functions is throwing errors `[Errno 1] Operation not permitted` when calling it. Replace it by `os.link` + `os.remove`
 
 **v0.5.0**
 - [Feature] Allow the file name from the download file to be manually overriden in `FileHook`

--- a/packages/airless-core/airless/core/hook/file.py
+++ b/packages/airless-core/airless/core/hook/file.py
@@ -158,7 +158,8 @@ class FileHook(BaseHook):
         to_filename_formatted = (
             '' if to_filename.startswith('/tmp/') else '/tmp/'
         ) + to_filename
-        os.rename(from_filename, to_filename_formatted)
+        os.link(from_filename, to_filename_formatted)
+        os.remove(from_filename)
         return to_filename_formatted
 
     def rename_files(self, dir, prefix):

--- a/packages/airless-core/pyproject.toml
+++ b/packages/airless-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-core"
-version = "0.5.0"
+version = "0.5.1"
 description = "Airless is a package that aims to build a serverless and lightweight orchestration platform, creating workflows of multiple tasks being executed on FaaS platform"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/airless-core/tests/core/hook/test_file.py
+++ b/packages/airless-core/tests/core/hook/test_file.py
@@ -1,4 +1,3 @@
-
 # import os
 import unittest
 
@@ -8,10 +7,9 @@ from airless.core.hook.file import FileHook, FtpHook
 
 
 class TestFileHook(unittest.TestCase):
-
     def setUp(self):
         self.file_hook = FileHook()
-    
+
     @patch('json.dump')
     @patch('builtins.open', new_callable=mock_open)
     def test_write_json(self, mock_file, mock_json_dump):
@@ -42,30 +40,34 @@ class TestFileHook(unittest.TestCase):
         tmp_filepath = self.file_hook.get_tmp_filepath(filepath)
         self.assertTrue(tmp_filepath.startswith('/tmp/'))
 
-    @patch("requests.get")
+    @patch('requests.get')
     def test_download(self, mock_get):
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.iter_content.return_value = [b"data"]
+        mock_response.iter_content.return_value = [b'data']
         mock_get.return_value = mock_response
 
         url = 'http://example.com/file.txt'
         headers = {'Authorization': 'Bearer token'}
         local_file = self.file_hook.download(url, headers)
-        
-        self.assertTrue(local_file.startswith('/tmp/'))
-        mock_get.assert_called_once_with(url, stream=True, verify=False, headers=headers, timeout=500, proxies=None)
 
-    @patch("os.rename")
-    def test_rename(self, mock_rename):
+        self.assertTrue(local_file.startswith('/tmp/'))
+        mock_get.assert_called_once_with(
+            url, stream=True, verify=False, headers=headers, timeout=500, proxies=None
+        )
+
+    @patch('os.remove')
+    @patch('os.link')
+    def test_rename(self, mock_link, mock_remove):
         from_filename = '/tmp/old_file.txt'
         to_filename = '/tmp/new_file.txt'
         result = self.file_hook.rename(from_filename, to_filename)
-        mock_rename.assert_called_once_with(from_filename, to_filename)
+        mock_link.assert_called_once_with(from_filename, to_filename)
+        mock_remove.assert_called_once_with(from_filename)
         self.assertEqual(result, to_filename)
 
-    @patch("os.walk")
-    @patch("os.rename")
+    @patch('os.walk')
+    @patch('os.rename')
     def test_rename_files(self, mock_rename, mock_walk):
         mock_walk.return_value = [
             ('/some/dir', ('subdir',), ('file1.txt', 'file2.txt')),
@@ -74,7 +76,7 @@ class TestFileHook(unittest.TestCase):
         mock_rename.assert_any_call('/some/dir/file1.txt', '/some/dir/prefix_file1.txt')
         mock_rename.assert_any_call('/some/dir/file2.txt', '/some/dir/prefix_file2.txt')
 
-    @patch("os.walk")
+    @patch('os.walk')
     def test_list_files(self, mock_walk):
         mock_walk.return_value = [
             ('/some/dir', ('subdir',), ('file1.txt', 'file2.txt')),
@@ -88,12 +90,12 @@ class TestFtpHook(unittest.TestCase):
         self.ftp_hook = FtpHook()
         self.ftp_hook.ftp = MagicMock()
 
-    @patch("airless.core.hook.file.FTP")
+    @patch('airless.core.hook.file.FTP')
     def test_login(self, mock_ftp):
         host = 'ftp.example.com'
         user = 'username'
         password = 'password'
-        
+
         self.ftp_hook.login(host, user, password)
 
         mock_ftp.assert_called_once_with(host, user, password)
@@ -106,12 +108,13 @@ class TestFtpHook(unittest.TestCase):
 
     @patch.object(FtpHook, 'cwd')
     def test_list(self, mock_cwd):
-
-        self.ftp_hook.dir = MagicMock(return_value=[
-            '05-21-20  09:00AM        <DIR>   subdir1',
-            '05-21-20  09:01AM                 1234 file1.txt',
-            '05-21-20  09:02AM                 5678 file2.txt'
-        ])
+        self.ftp_hook.dir = MagicMock(
+            return_value=[
+                '05-21-20  09:00AM        <DIR>   subdir1',
+                '05-21-20  09:01AM                 1234 file1.txt',
+                '05-21-20  09:02AM                 5678 file2.txt',
+            ]
+        )
         mock_cwd.return_value = None
 
         files, directories = self.ftp_hook.list()
@@ -122,8 +125,8 @@ class TestFtpHook(unittest.TestCase):
         self.assertEqual(files[0]['name'], 'file1.txt')
         self.assertEqual(files[1]['name'], 'file2.txt')
 
-    @patch("airless.core.hook.file.FtpHook.cwd")
-    @patch("builtins.open", new_callable=mock_open)
+    @patch('airless.core.hook.file.FtpHook.cwd')
+    @patch('builtins.open', new_callable=mock_open)
     def test_download(self, mock_file, mock_cwd):
         self.ftp_hook.cwd = MagicMock()
         filename = 'file.txt'
@@ -133,8 +136,11 @@ class TestFtpHook(unittest.TestCase):
 
         self.assertTrue(local_filepath.startswith('/tmp/'))
         self.ftp_hook.cwd.assert_called_once_with(directory)
-        self.ftp_hook.ftp.retrbinary.assert_called_once_with(f'RETR {filename}', mock_file().write)
+        self.ftp_hook.ftp.retrbinary.assert_called_once_with(
+            f'RETR {filename}', mock_file().write
+        )
 
 
 if __name__ == '__main__':
     unittest.main()
+

--- a/packages/airless-google-cloud-storage/.bumpversion.cfg
+++ b/packages/airless-google-cloud-storage/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.5.1
 commit = True
 tag = True
 tag_name = airless-google-cloud-storage_v{new_version}

--- a/packages/airless-google-cloud-storage/CHANGELOG.md
+++ b/packages/airless-google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,6 @@
 
 **unreleased**
+- [Bugfix] Only rename the file if needed, otherwise ignore because cloud run functions is throwing errors in this operation
 
 **v0.5.0**
 - [Feature] Allow the file name from the download file to be manually overriden in `FileHook`

--- a/packages/airless-google-cloud-storage/CHANGELOG.md
+++ b/packages/airless-google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,7 @@
 
 **unreleased**
+
+**v0.5.1**
 - [Bugfix] Only rename the file if needed, otherwise ignore because cloud run functions is throwing errors in this operation
 
 **v0.5.0**

--- a/packages/airless-google-cloud-storage/airless/google/cloud/storage/operator/file.py
+++ b/packages/airless-google-cloud-storage/airless/google/cloud/storage/operator/file.py
@@ -35,7 +35,7 @@ class FileUrlToGcsOperator(GoogleBaseEventOperator):
             override_filename=origin.get('filename'),
         )
 
-        self.move_to_destinations(local_filepath, destination)
+        local_filepath = self.move_to_destinations(local_filepath, destination)
 
         os.remove(local_filepath)
 
@@ -43,17 +43,21 @@ class FileUrlToGcsOperator(GoogleBaseEventOperator):
         self,
         local_filepath: str,
         destination: Union[Dict[str, Any], List[Dict[str, Any]]],
-    ) -> None:
+    ) -> str:
         """Moves the downloaded file to the specified destinations.
 
         Args:
             local_filepath (str): The local file path.
             destination (Union[Dict[str, Any], List[Dict[str, Any]]]): The destination(s) for the file.
+
+        Returns:
+            str: the current local file path, after file renaming
         """
         original_filepath = local_filepath
         destinations = destination if isinstance(destination, list) else [destination]
+        last = len(destinations) - 1
 
-        for dest in destinations:
+        for i, dest in enumerate(destinations):
             if dest.get('filename'):
                 local_filepath = self.file_hook.rename(
                     from_filename=local_filepath, to_filename=dest.get('filename')
@@ -82,10 +86,14 @@ class FileUrlToGcsOperator(GoogleBaseEventOperator):
                     ),
                 )
 
-                if local_filepath != original_filepath:  # revert to original filename
+                if (
+                    local_filepath != original_filepath and i != last
+                ):  # revert to original filename
                     local_filepath = self.file_hook.rename(
                         from_filename=local_filepath, to_filename=original_filepath
                     )
+
+        return local_filepath
 
     def remove_null_byte(self, local_filepath: str) -> None:
         """Removes null bytes from the specified file.

--- a/packages/airless-google-cloud-storage/airless/google/cloud/storage/operator/ftp.py
+++ b/packages/airless-google-cloud-storage/airless/google/cloud/storage/operator/ftp.py
@@ -1,4 +1,3 @@
-
 import os
 from typing import Dict
 
@@ -29,6 +28,6 @@ class FtpToGcsOperator(FileUrlToGcsOperator):
 
         local_filepath = self.ftp_hook.download(origin['directory'], origin['filename'])
 
-        self.move_to_destinations(local_filepath, destination)
+        local_filepath = self.move_to_destinations(local_filepath, destination)
 
         os.remove(local_filepath)

--- a/packages/airless-google-cloud-storage/pyproject.toml
+++ b/packages/airless-google-cloud-storage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airless-google-cloud-storage"
-version = "0.5.0"
+version = "0.5.1"
 description = "Airless package to work with google cloud storage"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## What was done

> Describe what was done in this PR and why it was done, while classifing it in `Feature`, `Bugfix` or `Refactor`

* [Bugfix] problem renaming file cloud run functions. replace `os.rename` by `os.link` + `os.remove`. For some unknown reason cloud run functions is not accepting `os.rename`. it raises an error `[Errno 1] Operation not permitted`

## Links to issues

> Github issues connected to this PR

